### PR TITLE
Cleanup Docker file

### DIFF
--- a/registry-4.5.2/Dockerfile
+++ b/registry-4.5.2/Dockerfile
@@ -1,7 +1,13 @@
 FROM jfrog-docker-reg2.bintray.io/jfrog/artifactory-registry:4.5.2
 MAINTAINER Patrick Tescher <pat2man@gmail.com>
 
-RUN yum install -y tar
+ENV MYSQL_DRIVER_VERSION=5.1.38
 
-ADD http://cdn.mysql.com/Downloads/Connector-J/mysql-connector-java-5.1.38.tar.gz /tmp/mysql-connector-java-5.1.38.tar.gz
-RUN cd /tmp; tar zxf mysql-connector-java-5.1.38.tar.gz; cp /tmp/mysql-connector-java-5.1.38/mysql-connector-java-5.1.38-bin.jar /var/opt/jfrog/artifactory/tomcat/lib
+ADD http://cdn.mysql.com/Downloads/Connector-J/mysql-connector-java-$MYSQL_DRIVER_VERSION.tar.gz /tmp
+
+RUN yum install -y tar && \
+    cd /tmp && \
+    tar zxf mysql-connector-java-$MYSQL_DRIVER_VERSION.tar.gz && \
+    cp /tmp/mysql-connector-java-$MYSQL_DRIVER_VERSION/mysql-connector-java-$MYSQL_DRIVER_VERSION-bin.jar /var/opt/jfrog/artifactory/tomcat/lib && \
+    rm -r /tmp/mysql-connector-java-* && \
+    yum remove -y tar


### PR DESCRIPTION
Make the image a bit smaller by combining the 2 RUN commands into 1
Made the file more readable by splitting the big RUN line into several lines
Cleanup the tmp folder and remove the tar package to make the image 13 MB smaller
